### PR TITLE
Notebook and pvcviewer support gateway api

### DIFF
--- a/components/common/reconcilehelper/util.go
+++ b/components/common/reconcilehelper/util.go
@@ -89,7 +89,7 @@ func VirtualService(ctx context.Context, r client.Client, virtualServiceName, na
 			return err
 		}
 	}
-	if !justCreated && CopyVirtualService(virtualservice, foundVirtualService) {
+	if !justCreated && CopyIngressResources(virtualservice, foundVirtualService) {
 		log.Info("Updating virtual service", "namespace", namespace, "name", virtualServiceName)
 		if err := r.Update(ctx, foundVirtualService); err != nil {
 			log.Error(err, "unable to update virtual service")
@@ -196,7 +196,7 @@ func CopyServiceFields(from, to *corev1.Service) bool {
 
 // Copy configuration related fields to another instance and returns true if there
 // is a diff and thus needs to update.
-func CopyVirtualService(from, to *unstructured.Unstructured) bool {
+func CopyIngressResources(from, to *unstructured.Unstructured) bool {
 	fromSpec, found, err := unstructured.NestedMap(from.Object, "spec")
 	if !found {
 		return false

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -199,12 +199,10 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
-	// Reconcile virtual service if we use ISTIO.
-	if os.Getenv("USE_ISTIO") == "true" {
-		err = r.reconcileVirtualService(instance)
-		if err != nil {
-			return ctrl.Result{}, err
-		}
+	// Reconcile network resource (e.g. VirtualService / HTTPRoute)
+	err = r.reconcileNetworkResource(instance)
+	if err != nil {
+		return ctrl.Result{}, err
 	}
 
 	foundPod := &corev1.Pod{}
@@ -464,7 +462,7 @@ func generateService(instance *v1beta1.Notebook) *corev1.Service {
 	return svc
 }
 
-func virtualServiceName(kfName string, namespace string) string {
+func networkResourceServiceName(kfName string, namespace string) string {
 	return fmt.Sprintf("notebook-%s-%s", namespace, kfName)
 }
 
@@ -494,7 +492,7 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	vsvc := &unstructured.Unstructured{}
 	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
 	vsvc.SetKind("VirtualService")
-	vsvc.SetName(virtualServiceName(name, namespace))
+	vsvc.SetName(networkResourceServiceName(name, namespace))
 	vsvc.SetNamespace(namespace)
 
 	istioHost := os.Getenv("ISTIO_HOST")
@@ -570,41 +568,145 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 
 }
 
-func (r *NotebookReconciler) reconcileVirtualService(instance *v1beta1.Notebook) error {
-	log := r.Log.WithValues("notebook", instance.Namespace)
-	virtualService, err := generateVirtualService(instance)
+func generateHttpRoute(instance *v1beta1.Notebook) (*unstructured.Unstructured, error) {
+	name := instance.Name
+	namespace := instance.Namespace
+	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	rewrite := prefix
+
+	// If AnnotationRewriteURI is present, use this value for "rewrite"
+	if val, ok := instance.ObjectMeta.Annotations[AnnotationRewriteURI]; ok && len(val) > 0 {
+		rewrite = val
+	}
+
+	hrvc := &unstructured.Unstructured{}
+	hrvc.SetAPIVersion("gateway.networking.k8s.io/v1")
+	hrvc.SetKind("HTTPRoute")
+	hrvc.SetName(networkResourceServiceName(name, namespace))
+	hrvc.SetNamespace(namespace)
+
+	istioGateway := os.Getenv("ISTIO_GATEWAY")
+	if len(istioGateway) == 0 {
+		istioGateway = "kubeflow/kubeflow-gateway"
+	}
+	parts := strings.Split(istioGateway, "/")
+	gatewayNamespace, gatewayName := parts[0], parts[1]
+
+	parentRefs := []interface{}{
+		map[string]interface{}{
+			"group":     "gateway.networking.k8s.io",
+			"kind":      "Gateway",
+			"name":      gatewayName,
+			"namespace": gatewayNamespace,
+		},
+	}
+	if err := unstructured.SetNestedSlice(hrvc.Object, parentRefs, "spec", "parentRefs"); err != nil {
+		return nil, fmt.Errorf("set .spec.parentRefs error: %v", err)
+	}
+	rules := []interface{}{
+		map[string]interface{}{
+			"backendRefs": []interface{}{
+				map[string]interface{}{
+					"group": "",
+					"kind":  "Service",
+					"name":  name,
+					"port":  int64(DefaultServingPort),
+				},
+			},
+			"matches": []interface{}{
+				map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":  "PathPrefix",
+						"value": prefix,
+					},
+				},
+			},
+			"filters": []interface{}{
+				map[string]interface{}{
+					"type": "URLRewrite",
+					"urlRewrite": map[string]interface{}{
+						"path": map[string]interface{}{
+							"replacePrefixMatch": rewrite,
+							"type": "ReplacePrefixMatch",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := unstructured.SetNestedSlice(hrvc.Object, rules, "spec", "rules"); err != nil {
+		return nil, fmt.Errorf("set .spec.rules error: %v", err)
+	}
+	return hrvc, nil
+
+}
+
+func (r *NotebookReconciler) reconcileNetworkResource(instance *v1beta1.Notebook) error {
+	log := r.Log.WithValues("notebook", instance.Namespace, "name", instance.Name)
+
+	var generateNetworkResourceFunc func(*v1beta1.Notebook) (*unstructured.Unstructured, error)
+
+	// istio is set to a higher priority
+	if os.Getenv("USE_ISTIO") == "true" {
+		log.Info("Using Istio configuration, generating VirtualService")
+		generateNetworkResourceFunc = generateVirtualService
+	} else if os.Getenv("USE_GATEWAY") == "true" {
+		log.Info("Using Gateway API configuration, generating HTTPRoute")
+		generateNetworkResourceFunc = generateHttpRoute
+	} else {
+		return nil
+	}
+
+	networkResource, err := generateNetworkResourceFunc(instance)
 	if err != nil {
-		log.Info("Unable to generate VirtualService...", err)
-		return err
-	}
-	if err := ctrl.SetControllerReference(instance, virtualService, r.Scheme); err != nil {
-		return err
-	}
-	// Check if the virtual service already exists.
-	foundVirtual := &unstructured.Unstructured{}
-	justCreated := false
-	foundVirtual.SetAPIVersion("networking.istio.io/v1alpha3")
-	foundVirtual.SetKind("VirtualService")
-	err = r.Get(context.TODO(), types.NamespacedName{Name: virtualServiceName(instance.Name,
-		instance.Namespace), Namespace: instance.Namespace}, foundVirtual)
-	if err != nil && apierrs.IsNotFound(err) {
-		log.Info("Creating virtual service", "namespace", instance.Namespace, "name",
-			virtualServiceName(instance.Name, instance.Namespace))
-		err = r.Create(context.TODO(), virtualService)
-		justCreated = true
-		if err != nil {
-			return err
-		}
-	} else if err != nil {
+		log.Error(err, "Failed to generate network resource")
 		return err
 	}
 
-	if !justCreated && reconcilehelper.CopyVirtualService(virtualService, foundVirtual) {
-		log.Info("Updating virtual service", "namespace", instance.Namespace, "name",
-			virtualServiceName(instance.Name, instance.Namespace))
-		err = r.Update(context.TODO(), foundVirtual)
-		if err != nil {
-			return err
+	if err := ctrl.SetControllerReference(instance, networkResource, r.Scheme); err != nil {
+		log.Error(err, "Failed to set controller reference")
+		return err
+	}
+
+	if err := r.createOrUpdateNetworkResource(instance, networkResource); err != nil {
+		log.Error(err, "Failed to reconcile network resource")
+		return err
+	}
+
+	return nil
+}
+
+func (r *NotebookReconciler) createOrUpdateNetworkResource(instance *v1beta1.Notebook, networkResource *unstructured.Unstructured) error {
+	log := r.Log.WithValues("notebook", instance.Namespace)
+
+	name := types.NamespacedName{
+		Name:      networkResource.GetName(),
+		Namespace: instance.Namespace,
+	}
+	foundResource := &unstructured.Unstructured{}
+	foundResource.SetAPIVersion(networkResource.GetAPIVersion())
+	foundResource.SetKind(networkResource.GetKind())
+
+	err := r.Get(context.TODO(), name, foundResource)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("Creating network resource", "namespace", instance.Namespace, "name", name.Name)
+			if createErr := r.Create(context.TODO(), networkResource); createErr != nil {
+				log.Error(createErr, "Failed to create network resource")
+				return createErr
+			}
+			return nil
+		}
+		log.Error(err, "Failed to get network resource")
+		return err
+	}
+
+	if reconcilehelper.CopyIngressResources(networkResource, foundResource) {
+		log.Info("Updating network resource", "namespace", instance.Namespace, "name", name.Name)
+		if updateErr := r.Update(context.TODO(), foundResource); updateErr != nil {
+			log.Error(updateErr, "Failed to update network resource")
+			return updateErr
 		}
 	}
 

--- a/components/pvcviewer-controller/controllers/pvcviewer_controller.go
+++ b/components/pvcviewer-controller/controllers/pvcviewer_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
@@ -132,8 +133,8 @@ func (r *PVCViewerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileVirtualService(ctx, log, instance, commonLabels); err != nil {
-		log.Error(err, "Error while reconciling virtual service")
+	if err := r.reconcileNetworkResource(ctx, log, instance, commonLabels); err != nil {
+		log.Error(err, "Error while reconciling network resource")
 		return ctrl.Result{}, err
 	}
 
@@ -249,91 +250,6 @@ func (r *PVCViewerReconciler) reconcileService(ctx context.Context, log logr.Log
 	return r.Update(ctx, service)
 }
 
-func (r *PVCViewerReconciler) reconcileVirtualService(ctx context.Context, log logr.Logger, viewer *kubefloworgv1alpha1.PVCViewer, commonLabels map[string]string) error {
-	if viewer.Spec.Networking == (kubefloworgv1alpha1.Networking{}) {
-		return nil
-	}
-
-	virtualService := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "networking.istio.io/v1alpha3",
-			"kind":       "VirtualService",
-			"metadata": map[string]interface{}{
-				"name":      resourcePrefix + viewer.Name,
-				"namespace": viewer.Namespace,
-				"labels":    commonLabels,
-			},
-		},
-	}
-	createVirtualService := false
-	if err := r.Get(ctx, types.NamespacedName{Name: virtualService.GetName(), Namespace: virtualService.GetNamespace()}, virtualService); err != nil {
-		if !apierrs.IsNotFound(err) {
-			return err
-		}
-		createVirtualService = true
-	}
-
-	prefix := fmt.Sprintf("%s/%s/%s/", viewer.Spec.Networking.BasePrefix, viewer.Namespace, viewer.Name)
-	rewrite := prefix
-	if viewer.Spec.Networking.Rewrite != "" {
-		rewrite = viewer.Spec.Networking.Rewrite
-	}
-	service := fmt.Sprintf("%s%s.%s.svc.cluster.local", resourcePrefix, viewer.Name, viewer.Namespace)
-	var timeout *string = nil
-	if viewer.Spec.Networking.Timeout != "" {
-		timeout = &viewer.Spec.Networking.Timeout
-	}
-
-	// Get the istio gateway from the environment variable or use the default
-	istioGateway := os.Getenv(istioGatewayEnvKey)
-	if istioGateway == "" {
-		istioGateway = defaultIstioGateway
-	}
-
-	virtualService.Object["spec"] = map[string]interface{}{
-		"hosts": []string{"*"},
-		"gateways": []string{
-			istioGateway,
-		},
-		"http": []interface{}{
-			map[string]interface{}{
-				"match": []interface{}{
-					map[string]interface{}{
-						"uri": map[string]interface{}{
-							"prefix": prefix,
-						},
-					},
-				},
-				"rewrite": map[string]interface{}{
-					"uri": rewrite,
-				},
-				"route": []interface{}{
-					map[string]interface{}{
-						"destination": map[string]interface{}{
-							"host": service,
-							"port": map[string]interface{}{
-								"number": int64(servicePort),
-							},
-						},
-					},
-				},
-				"timeout": timeout,
-			},
-		},
-	}
-
-	if err := ctrl.SetControllerReference(viewer, virtualService, r.Scheme); err != nil {
-		return err
-	}
-
-	if createVirtualService {
-		log.Info("Creating Virtual Service")
-		return r.Create(ctx, virtualService)
-	}
-	log.Info("Updating Virtual Service")
-	return r.Update(ctx, virtualService)
-}
-
 // Computes and updates the status of the PVCViewer
 func (r *PVCViewerReconciler) reconcileStatus(ctx context.Context, log logr.Logger, viewerName string, viewerNamespace string) error {
 	viewer := &kubefloworgv1alpha1.PVCViewer{}
@@ -365,6 +281,187 @@ func (r *PVCViewerReconciler) reconcileStatus(ctx context.Context, log logr.Logg
 
 	log.Info("Updating status")
 	return r.Client.Status().Update(ctx, viewer)
+}
+
+func (r *PVCViewerReconciler) reconcileNetworkResource(ctx context.Context, log logr.Logger, viewer *kubefloworgv1alpha1.PVCViewer, commonLabels map[string]string) error {
+	if viewer.Spec.Networking == (kubefloworgv1alpha1.Networking{}) {
+		return nil
+	}
+
+	var generateNetworkResourceFunc func(*kubefloworgv1alpha1.PVCViewer, string) (*unstructured.Unstructured, error)
+
+	if os.Getenv("USE_GATEWAY") == "true" {
+		log.Info("Using Gateway API configuration, generating HTTPRoute")
+		generateNetworkResourceFunc = generateHttpRoute
+	} else {
+		// This is the default behavior, I didn't make any changes.
+		log.Info("Using Istio configuration, generating VirtualService")
+		generateNetworkResourceFunc = generateVirtualService
+	}
+
+	istioGateway := os.Getenv(istioGatewayEnvKey)
+	if istioGateway == "" {
+		istioGateway = defaultIstioGateway
+	}
+
+	networkResource, err := generateNetworkResourceFunc(viewer, istioGateway)
+	if networkResource == nil {
+		log.Error(fmt.Errorf("network resource generation failed"), "Network resource is nil")
+		return fmt.Errorf("failed to generate network resource")
+	}
+
+	networkResource.SetLabels(commonLabels)
+	networkResource.SetName(resourcePrefix + viewer.Name)
+	networkResource.SetNamespace(viewer.Namespace)
+
+	if err != nil {
+		log.Error(err, "Failed to generate network resource")
+		return err
+	}
+
+	if err := ctrl.SetControllerReference(viewer, networkResource, r.Scheme); err != nil {
+		log.Error(err, "Failed to set controller reference")
+		return err
+	}
+
+	if err := r.createOrUpdateNetworkResource(ctx, log, networkResource); err != nil {
+		log.Error(err, "Failed to reconcile network resource")
+		return err
+	}
+
+	return nil
+}
+
+func (r *PVCViewerReconciler) createOrUpdateNetworkResource(ctx context.Context, log logr.Logger, networkResource *unstructured.Unstructured) error {
+	existingResource := &unstructured.Unstructured{}
+	existingResource.SetAPIVersion(networkResource.GetAPIVersion())
+	existingResource.SetKind(networkResource.GetKind())
+
+	err := r.Get(ctx, types.NamespacedName{Name: networkResource.GetName(), Namespace: networkResource.GetNamespace()}, existingResource)
+	if err != nil {
+		if apierrs.IsNotFound(err) {
+			log.Info("Creating network resource", "name", networkResource.GetName(), "namespace", networkResource.GetNamespace())
+			return r.Create(ctx, networkResource)
+		}
+		return err
+	}
+
+	log.Info("Updating network resource", "name", networkResource.GetName(), "namespace", networkResource.GetNamespace())
+	networkResource.SetResourceVersion(existingResource.GetResourceVersion())
+	return r.Update(ctx, networkResource)
+}
+
+func generateVirtualService(viewer *kubefloworgv1alpha1.PVCViewer, istioGateway string) (*unstructured.Unstructured, error) {
+	prefix, rewrite := calculatePrefixes(viewer)
+	service := fmt.Sprintf("%s%s.%s.svc.cluster.local", resourcePrefix, viewer.Name, viewer.Namespace)
+	var timeout *string = nil
+	if viewer.Spec.Networking.Timeout != "" {
+		timeout = &viewer.Spec.Networking.Timeout
+	}
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "networking.istio.io/v1alpha3",
+			"kind":       "VirtualService",
+			"spec": map[string]interface{}{
+				"hosts": []string{"*"},
+				"gateways": []string{
+					istioGateway,
+				},
+				"http": []interface{}{
+					map[string]interface{}{
+						"match": []interface{}{
+							map[string]interface{}{
+								"uri": map[string]interface{}{
+									"prefix": prefix,
+								},
+							},
+						},
+						"rewrite": map[string]interface{}{
+							"uri": rewrite,
+						},
+						"route": []interface{}{
+							map[string]interface{}{
+								"destination": map[string]interface{}{
+									"host": service,
+									"port": map[string]interface{}{
+										"number": int64(servicePort),
+									},
+								},
+							},
+						},
+						"timeout": timeout,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func generateHttpRoute(viewer *kubefloworgv1alpha1.PVCViewer, istioGateway string) (*unstructured.Unstructured, error) {
+	prefix, rewrite := calculatePrefixes(viewer)
+	parts := strings.Split(istioGateway, "/")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid istioGateway format: %s", istioGateway)
+	}
+	gatewayNamespace, gatewayName := parts[0], parts[1]
+
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "gateway.networking.k8s.io/v1",
+			"kind":       "HTTPRoute",
+			"spec": map[string]interface{}{
+				"parentRefs": []interface{}{
+					map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "Gateway",
+						"name":      gatewayName,
+						"namespace": gatewayNamespace,
+					},
+				},
+				"rules": []interface{}{
+					map[string]interface{}{
+						"backendRefs": []interface{}{
+							map[string]interface{}{
+								"group": "",
+								"kind":  "Service",
+								"name":  resourcePrefix + viewer.Name,
+								"port":  int64(servicePort),
+							},
+						},
+						"matches": []interface{}{
+							map[string]interface{}{
+								"path": map[string]interface{}{
+									"type":  "PathPrefix",
+									"value": prefix,
+								},
+							},
+						},
+						"filters": []interface{}{
+							map[string]interface{}{
+								"type": "URLRewrite",
+								"urlRewrite": map[string]interface{}{
+									"path": map[string]interface{}{
+										"replacePrefixMatch": rewrite,
+										"type": "ReplacePrefixMatch",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}
+
+func calculatePrefixes(viewer *kubefloworgv1alpha1.PVCViewer) (string, string) {
+	prefix := fmt.Sprintf("%s/%s/%s/", viewer.Spec.Networking.BasePrefix, viewer.Namespace, viewer.Name)
+	rewrite := prefix
+	if viewer.Spec.Networking.Rewrite != "" {
+		rewrite = viewer.Spec.Networking.Rewrite
+	}
+	return prefix, rewrite
 }
 
 // Generates the affinity to be used for the deployment


### PR DESCRIPTION
Currently, `notebook` and `pvcview` do not support Kubernetes Gateway network resources. To address this, we have made the following changes:  
- If the environment variable USE_GATEWAY is set to true, an HTTPRoute will be created; otherwise, the original behavior will be maintained.
- If both `USE_GATEWAY` and `USE_ISTIO` are set to `true`, the original behavior remains unchanged.  
